### PR TITLE
use send instead of sendto

### DIFF
--- a/pyvban/utils/send_text.py
+++ b/pyvban/utils/send_text.py
@@ -37,7 +37,7 @@ class VBAN_SendText:
 
             data = header.to_bytes() + text.encode("utf-8")
             data = data[:VBAN_PROTOCOL_MAX_SIZE]
-            self._socket.sendto(data, self._receiver)
+            self._socket.send(data)
         except Exception as e:
             self._logger.error(f"An exception occurred: {e}")
 

--- a/pyvban/utils/sender.py
+++ b/pyvban/utils/sender.py
@@ -55,7 +55,7 @@ class VBAN_Sender:
             data = header.to_bytes() + self._stream.read(self._samples_per_frame)
             data = data[:VBAN_PROTOCOL_MAX_SIZE]
 
-            self._socket.sendto(data, self._receiver)
+            self._socket.send(data)
         except Exception as e:
             self._logger.error(f"An exception occurred: {e}")
 


### PR DESCRIPTION
Running on python3.12 will encounter
`An exception occurred: [Errno 56] Socket is already connected`
switching from sendto to send can solve this problem.